### PR TITLE
Link directly to governing board members

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Open source software has become pervasive in data centers, consumer devices, and
 
 * [OpenSSF Funding Charter](https://github.com/ossf/foundation/blob/main/Review%20Copy%20Only%20-%20Not%20for%20Execution_OpenSSF%20Participation%20Agreement%20and%20Charter%20(rev.%202020%2009%2011).pdf)
 * [OpenSSF Technical Charter Template](https://github.com/ossf/project-template/blob/main/CHARTER.md)
+* [OpenSSF Governing Board members](https://openssf.org/about/governing-board/)
 
 # Get Involved!
 * [Open SSF Community Calendar](https://calendar.google.com/calendar/r?cid=czYzdm9lZmhwNWk5cGZsdGI1cTY3bmdwZXNAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ)


### PR DESCRIPTION
An obvious question many will ask about the OpenSSF is "who is on the governing board"? Add a link to directly answer that question. It's possible to go the website, and then find it, but I think it's better to answer that one directly.