### PR TITLE
convert word to markdown of charter

### DIFF
--- a/openssf-charter.md
+++ b/openssf-charter.md
@@ -1,0 +1,447 @@
+<center><h5>THE LINUX FOUNDATION</h5></center>
+
+<center><h5>THE OPEN SOURCE SECURITY FOUNDATION (OPENSSF)</h5></center>
+<center><h6>Participation Agreement</h6></center>
+
+Thank you for your interest in joining the Open Source Security Foundation (the "OpenSSF"), a project of The Linux Foundation (the "LF"). The mission of the OpenSSF is to inspire and enable the community to secure the open source software we all depend on, including development, testing, fundraising, infrastructure, and support initiatives driven by Working Groups and Projects (each a "Technical Initiative"). The governance for the OpenSSF will operate pursuant to the OpenSSF Charter (the "Charter"), set forth as [Exhibit B](#exb), and as amended in the future by the OpenSSF's Governing Board with the approval of the LF. **Please note** that you must be a member of the LF to be eligible to participate as a member of the OpenSSF. For further information, visit the [Corporate Membership](https://www.linuxfoundation.org/membership/join/) page at the LF web site.
+
+Participants will enjoy the privileges and undertake the obligations described in the Charter and will comply with all such policies as the LF Board of Directors and/or the OpenSSF's Governing Board may from time to time adopt with notice to members. The LF reserves the right to refuse any Participation Agreement submitted by a member who has apayment obligations outstanding to the LF or to any other LF projectdirected funds. Technical oversight governance for any Technical Initiative is set forth in the applicable charter for each such Technical Initiative.
+
+Please have this Participation Agreement (the "Agreement") executed by an authorized representative of the member company named below ("Member") and send a copy in PDF form by email to [membership\@linuxfoundation.org](mailto:membership@linuxfoundation.org). A countersigned copy will be returned to you by email for your records when your eligibility for membership has been confirmed and an invoice will be emailed to you if any payment of applicable membership fees is required. Note that this is not an indication of interest; execution of this Agreement creates an irrevocable, binding obligation for the member company to make the payments provided for and to otherwise perform in accordance with its terms.
+
+**Contact Information**
+
+If you are an existing LF Member, all legal, billing and financial notices from the LF relating to your participation will be sent to the individuals already on file with the LF under those categories unless you designate a different individual in [Exhibit A](#exa).
+
+**Membership Term**
+
+Membership will begin on acceptance as a member and the initial membership term will continue until the first anniversary of membership. At the first anniversary of membership, if membership is not canceled at least thirty days prior to the first anniversary of membership, the second membership term will be prorated for the remainder of that calendar year (a "stub period"), bringing the membership term inline with a calendar year cycle starting at the first anniversary of membership. The OpenSSF does not plan to require any participation fees during the initial membership term. Any participation fees instituted by the Governing Board at a later time will be invoiced according to each annual membership term or prorated for a stub period.
+
+**General Membership Terms**
+
+Agreements completed and accepted before the 15th of the month will begin the membership term as if active on the first day of the month of signature. Agreements signed on or after the 15th of the month will begin the membership term as if active on the 1st day of the following month. We reserve the right to refuse your Participation Agreement if you have outstanding obligations to the LF or any other LF projects. In no event will fees be refunded, upon a Member's resignation or otherwise.
+
+Each Member acknowledges that the LF and other members of the OpenSSF depend upon reliable renewal information to budget effectively, and that the LF's ability to provide services to the OpenSSF would suffer in the event of nonpayment of your LF membership fees. Each Member acknowledges The Linux Foundation's Good Standing Policy, available at https://www.linuxfoundation.org/good-standing-policy.
+
+Membership in the OpenSSF will renew annually for successive terms,unless written notice of non-renewal is delivered to the LF on or before December 1 of the current membership year.
+
+<center>[REMAINDER OF THIS PAGE INTENTIONALLY LEFT BLANK]</center>
+<div style="page-break-after: always"> </div>
+
+**Name of Member Company:**
+\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_
+
+**Membership Level** ([see Exhibit C](#exc))**:**
+\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_
+
+**Consolidated Employees** (*if applicable*)**:**
+\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_
+
+**PR/Logo Usage:** Do we have your permission to:
+* display your logo on the Directed Fund's website (Yes or No)?
+\_\_\_\_\_\_\_
+
+* announce your participation via press release (Yes or No)?
+\_\_\_\_\_\_\_
+
+**Preferred method(s) for receiving invoices** (*PDF or Hard Copy*):
+\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_
+
+**Is a Purchase Order (PO) required** (*Yes or No*)? \_\_\_\_\_\_\_
+
+If Yes, please provide the following details:
+
+Name:
+\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_
+
+E-mail:
+\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_
+
+By signing below, the Member acknowledges and agrees that, when signed and accepted by the LF, this Agreement represents a binding contract between the parties and commits the applicant to these terms and obligations:
+
+Authorized Representative of Member: Accepted:
+
+|_______________________________|  | THE LINUX FOUNDATION |
+|---------------------|--|----------------------|
+| (Print Member Name) |  |   |             
+|_______________________________|  |_______________________________|               
+| Signature       ||         Signature|   
+|_______________________________|  |_______________________________| 
+| Name         | |            Name |
+|_______________________________|  |_______________________________| 
+| Title         | |            Title |                           
+|_______________________________|  |_______________________________| 
+| Date         | |            Date |    
+
+<div style="page-break-after: always"></div>
+
+<center><h5><a name="exa"></a>Exhibit A</h5></center>
+
+**Primary Project Contact**
+
+*(for all notices, including voting)*
+
+Name: \_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_
+
+Title: \_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_
+
+Phone No: \_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_
+
+E-mail: \_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_
+
+**Primary Technical Contact**
+
+Name: \_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_
+
+Title: \_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_
+
+Phone No: \_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_
+
+E-mail: \_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_
+
+**Primary Marketing Contact**
+
+Name: \_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_
+
+Title: \_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_
+
+Phone No: \_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_
+
+E-mail: \_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_
+
+**Primary PR Contact**
+
+*(For approving press releases or quotes with respect to the Project)*
+
+Name: \_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_
+
+Title: \_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_
+
+Phone No: \_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_
+
+E-mail: \_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_
+
+**Legal Contact**
+
+*(This contact should be your primary in-house attorney for open source
+matters with respect to the Project. If you do not have in-house
+counsel, please leave this blank.)*
+
+Name: \_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_
+
+Title: \_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_
+
+Phone No: \_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_
+
+E-mail: \_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_
+
+**Billing Address**
+
+\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_
+
+\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_
+
+\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_
+
+**Billing Contact**
+
+*(All invoices will be sent to this e-mail address unless the Member
+directs otherwise)*
+
+Name: \_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_
+
+Title: \_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_
+
+Phone No: \_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_
+
+E-mail: \_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_
+
+<div style="page-break-after: always"> </div>
+
+<center><h5><a name="exb"></a>Exhibit B</h5></center>
+<center><h5>The Open Source Security Foundation Charter</h5></center>
+<center><h6>As Amended 10 November 2020</h6></center>
+
+
+1. **Mission and Scope of the Open Source Security Foundation.**
+<ol type="a">
+  <li>The purpose of the Open Source Security Foundation (the "OpenSSF") is to inspire and enable the community to secure the open source software we all depend on, including development, testing, fundraising, infrastructure, and support initiatives driven by Working Groups (non-software focused) and Projects (software focused), each a "Technical Initiative". The governance of each Technical Initiative will be as set forth in the applicable charter for each Technical Initiative. Participation in Technical Initiatives will be open to anyone, regardless of membership.</li>
+<br/>
+  <li>The OpenSSF supports the Technical Initiatives. The OpenSSF operates under the guidance of the Governing Board of the OpenSSF (the "Governing Board") and The Linux Foundation (the "LF") as may be consistent with The Linux Foundation's tax-exempt status.</li>
+<br/>
+  <li>The Governing Board manages the OpenSSF. The OpenSSF will also have Committees that may be established by the Governing Board. Committees report to the Governing Board. Working Groups and Projects may be established under the Technical Advisory Council (the "TAC").</li></ol>
+
+2. **Membership.**
+<ol type="a">
+  <li>The OpenSSF will be composed of OpenSSF Members (each, a "Member" and, collectively, the "Members") in Good Standing. All OpenSSF Members must be current corporate members of the LF (at any level) to participate in the OpenSSF as a OpenSSF Member. All participants in the OpenSSF, enjoy the privileges and undertake the obligations described in this Charter, as from time to time amended by the Governing Board with the approval of the LF. During the term of their membership, all OpenSSF Members will comply with all such policies as the LF Board of Directors and/or the OpenSSF may adopt with notice to members.</li>
+<br/>
+  <li>OpenSSF Members will be entitled to participate with the benefits afforded all OpenSSF Members.</li>
+<br/>
+  <li>The Associate Member category of OpenSSF Membership is limited to Associate Members of The Linux Foundation. The Governing Board may establish additional criteria for joining the OpenSSF as an Associate Member. If the Associate Member is a membership organization, Associate Membership in the OpenSSF does not confer any benefits or rights to the members of the Associate Member. </li>
+<br/>
+  <li>OpenSSF Members will be entitled to:</li>
+<br/>
+  <ol type="i">
+    <li>participate in OpenSSF general meetings, initiatives, events and any other activities; and</li>
+<br/>
+    <li>identify themselves as members of the Open Source Security Foundation and have their logo or name displayed on materials denoting the OpenSSF Members.</li></ol></ol>
+
+3. **Governing Board**
+<ol type="a">
+   <li>The Governing Board voting membership will consist of: </li>
+<br/>
+  <ol type="i">
+    <li>ten OpenSSF Member Representatives selected by the OpenSSF Members; </li>
+<br/>
+    <li>one TAC Representative (as defined herein);</li>
+<br/>
+    <li>one Associate Member Representative appointed by the OSSC
+             Governing Board; and</li>
+<br/>
+    <li>iv. one Security Community Individual Representative elected by contributors to Technical Initiatives.</li>
+  </ol>
+<br/>
+
+  <li>The initial OpenSSF Member Representatives will consist of:</li>
+  <br/>
+
+  <ol type="i">
+    <li>seven representatives appointed by each of the Initiating Members: GitHub, Google, IBM, JPMorgan Chase, Microsoft, NCC Group, and Red Hat;</li>
+    <br/>
+    <li>three representatives elected by the OpenSSF Members three months after OpenSSF's public announcement;</li>
+  </ol>
+  <br/>
+  <li>Terms</li>
+  <br/>
+    <ol type="i">
+      <li>The initial OpenSSF Member Representatives will serve an initial term ending one year after the OpenSSF public announcement.</li>
+      <br/>
+      <li>After the initial term, five OpenSSF Member Representatives will be randomly selected to continue an additional one year term, and five OpenSSF Member Representative positions will be up for election to a twenty four month term. Thereafter the OpenSSF Member Representatives will be chosen by staggered election for two year terms.</li>
+      <br/>
+      <li>The TAC Representative, Associate Member Representative,
+             and Security Community Individual Representative will each serve one year terms coinciding with the OpenSSF Member Representative elections.</li>
+      <br/>
+    </ol>
+    <li>The OpenSSF Member Representatives represent the member company and may be replaced by the member company.</li>
+          <br/>
+    <li>The TAC Representative, Associate Member Representative, and Security Community Individual Representatives will each serve a one-year term.</li>
+          <br/>
+    <li>At most two OpenSSF Members, including individuals employed by an OpenSSF Member, that are part of a group of Related Companies (as defined in Section 8) may serve as voting members of the Governing Board. </li>
+          <br/>
+    <li>Conduct of Meetings</li>
+          <br/>
+      <ol type="i"><li>Governing Board meetings will be limited to the Governing Board representatives, Committee chairpersons, invited guests and LF staff. </li>
+            <br/>
+      <li>Governing Board meetings follow the requirements for quorum and voting outlined in this Charter. The Governing Board may decide whether to allow named representatives to attend as an alternate or observer.</li>
+            <br/>
+      <li>The Governing Board meetings will be private unless decided otherwise by the Governing Board. The Governing Board may invite guests (e.g. committee chairpersons) to participate in consideration of specific Governing Board topics (but such guest may not participate in any vote on any matter before the Governing Board). The Governing Board may choose to hold open, community meetings at its discretion. </li>
+            <br/>
+    </ol>
+    <li>Officers</li>
+          <br/>
+      <ol type="i">
+      <li>The officers ("Officers") of the OpenSSF Governing Board will be a Chairperson ("Chair"). Additional Officer positions may be created by the Governing Board.</li>
+      <br/>
+      <li>The Chair will preside over meetings of the Governing Board, manage any day-to-day operational decisions, and will submit minutes for Governing Board approval. </li>
+            <br/>
+      <li>If the OpenSSF chooses to raise funds, the chair of the budget committee will assist LF staff in the preparation of budgets for Governing Board approval, monitor expenses against the budget and authorize expenditures approved in the budget. </li>
+            <br/>
+      <li>Officers will serve for a period of one year until their successors are elected and qualified. </li>
+            <br/>
+      </ol>
+    <li>The Governing Board will be responsible for overall management of the OpenSSF, including: </li>
+          <br/>
+      <ol type="i">
+        <li>approve procedures for the nomination and election of any representative to the Governing Board and any Officer or other positions created by the Governing Board;</li>
+              <br/>
+        <li>Establish any criteria for organizations to become Associate
+            Members of the OpenSSF;</li>
+                  <br/>
+        <li>oversee all OpenSSF business and community outreach matters and work with the LF on any legal matters that arise;</li>
+              <br/>
+        <li>adopt and maintain policies or rules and procedures for the OpenSSF (subject to LF approval);</li>
+              <br/>
+        <li>nominate and elect Officers of the OpenSSF Governing Board;</li>
+              <br/>
+        <li>establish advisory bodies, committees, programs or councils to support the mission of the OpenSSF and/or its Technical Initiatives, including in support of end-users and ambassadors for the project;</li>
+              <br/>
+        <li>approve a budget directing the use of funds raised by the OpenSSF from all sources of revenue for the OpenSSF;</li>
+              <br/>
+        <li>approve directed fundraising proposals for specific Working Groups or Projects that will raise and spend funds within the Working Group or Project;</li>
+              <br/>
+        <li>establish any conformance programs and solicit input
+            > (including testing tools) from the applicable governance
+            > body of any Technical Initiative for defining and
+            > administering any programs related to conformance with any
+            > Technical Initiative (each, a "Conformance Program");</li>
+              <br/>
+        <li>publish use cases, user stories, websites and priorities to
+            help inform the ecosystem and technical community; and</li>
+              <br/>
+        <li>vote on all decisions or matters coming before the Governing Board.</li>
+      </ol>
+    </ol>
+
+4. **Committees**
+  <ol type="a">
+    <li>Any Committee may include one appointed voting representative from each Governing Board Representative. Except for the Legal Committee, all OpenSSF Members may appoint a non-voting representative to participate and contribute in Committees. </li>
+    </br>
+    <li>The Governing Board will define the purpose and scope of each Committee. Committees are expected to coordinate closely with the Governing Board and relevant technical communities to
+    maximize consensus building throughout the OpenSSF.</li>
+    </br>
+    <li>The Governing Board may appoint a chairperson of any Committee or delegate responsibility for selecting a chairperson to a Committee. Each Committee chairperson will be responsible for reporting progress back to the Governing Board. A Committee  chairperson may attend meetings of the Governing Board, but, unless the Committee chairperson is a member of the Governing Board, the Committee chairperson will not attend as a voting member of the Governing Board.</li>
+  </ol>
+
+5. **Legal Committee**
+  <ol type="a"><li>The Legal Committee will consist of members of the Governing Board that wish to participate on the Legal Committee together with their legal counsel. Participation on the Legal Committee is voluntary, and the makeup of the Legal Committee will be determined annually or as otherwise directed by the Governing Board.</li>
+        </br>
+    <li>The responsibilities of the Legal Committee include the creation of recommendations to the Governing Board in response to questions submitted to the Legal Committee by the Governing Board or the TAC.</li>
+  </ol>
+
+6. **Technical Advisory Council**
+<ol type="a">
+  <li>For the first six months after OpenSSF's public announcement, the TAC will initially be composed of seven voting technical  representatives appointed by each of the Initiating Members.</li>
+  </br>
+  <li>After the initial six months, the TAC will be composed of both OpenSSF Member and Technical Initiative representatives as determined by the TAC.</li>
+  </br>
+  <li>The TAC will review for approval the Bootstrap Technical
+        Initiatives:</li>
+  </br>
+  <ol type="i">
+    <li>Vulnerability Disclosures</li>
+  </br>
+    <li>Security Tooling</li>
+  </br>
+    <li>Security Best Practices</li>
+  </br>
+    <li>Identifying Security Threats to Open Source Projects</li>
+  </br>
+    <li>Securing Critical Projects</li>
+  </br>
+    <li>Developer Identity Verification</li>
+  </br>
+  </ol>
+  <li>OpenSSF Members that are part of a group of Related Companies (as defined in Section 8) may have no more than two voting representatives on the TAC.</li>
+</br>
+    <li>The role of the TAC is to structure and facilitate collaboration among the Technical Initiatives. The TAC will be responsible
+        for:</li>
+    <ol type="i">
+      <li>developing an overall technical vision for the community;</li>
+      </br>
+      <li>establishing, structuring, organizing, and archiving Technical Initiatives, including the approval of the Technical Initiative charter;</li>
+      </br>
+      <li>creating, maintaining and amending project lifecycle states, review procedures and processes;</li>
+</br>
+      <li>working with the Technical Initiatives to identify any resource or funding requirements and prioritizing recommendations to the Governing Board;</li>
+</br>
+      <li>annually electing a chairperson to preside over meetings, set the agenda for meetings, ensure meeting minutes are taken, and who (subject to the provisions of Section 6.g) will also serve on the Governing Board as the TAC's representative (the "TAC Representative"); and</li>
+</br>
+      <li>coordinating such other technical community matters related to the success of Technical Initiatives and the mission of the OpenSSF.</li>
+</br>
+      <li>TAC, Working Group and Project meetings shall be open, public
+        meetings. For special circumstances, the TAC may hold meetings
+        limited to the TAC voting representatives, invited guests, and
+        LF staff.</li>
+</br>
+      <li>If the TAC chairperson cannot vote on the Governing Board by operation of Section 3.f., then the TAC will select another of its representatives (who will not be prohibited from voting on the Governing Board by operation of Section 3.f.) to be the TAC Representative.</li>
+      </ol>
+  </ol>
+
+7. **Voting**
+<ol type="a">
+  <li>Quorum for Governing Board, Committee, and TAC meetings will require at least fifty percent of the voting representatives in good standing. If advance notice of the meeting has been given per normal means and timing, with at least 7 days notice for meetings to make ordinary decisions, the meeting may continue to meet even if quorum is not met, but will be prevented from  making any decisions at the meeting.</li>
+</br><ol type="i">
+      <li>A voting representative must have attended two of the preceding three meetings to be counted as in good standing for the purposes of Quorum. Voting rights will be reinstated at the meeting after the voting representative has attended two of the prior three meetings.</li></ol>
+</br>
+      <li>Ideally decisions will be made based on consensus. If, however, any decision requires a vote to move forward, the voting representatives will vote on a one vote per voting representative basis.</li>
+</br>
+      <li>Except as provided in Section 15.a. or elsewhere in this Charter, decisions by vote at a meeting will require a simple majority vote, provided quorum is met. Except as provided in Section 15.a. or elsewhere in this Charter, decisions by electronic vote without a meeting will require a majority of all voting representatives.</li>
+</br>
+      <li>In the event of a tied vote with respect to an action that  cannot be resolved by the TAC, the TAC Representative may refer the matter to the Governing Board. In the event of a tied vote with respect to an action that cannot be resolved by the Governing Board, the chairperson may refer the matter to the LF for assistance in facilitating a decision.</li>
+      </ol>
+
+8. **Subsidiaries and Related Companies**
+<ol type="a">
+  <li>Definitions:
+</br>
+  <ol type="i">
+    <li>"Subsidiaries" means any entity in which a Member owns, directly or indirectly, more than fifty percent of the voting securities or voting membership interests of the entity in question;</li>
+</br>
+      <li>"Related Company" means any entity which controls or is controlled by a Member or which, together with a Member, is under the common control of a third party, in each case where such control results from ownership, either directly or indirectly, of more than fifty percent of the voting securities or voting membership interests of the entity in question; and</li>
+</br>
+      <li>"Related Companies" are entities that are each a Related  Company of a Member.</li></ol>
+</br>
+    <li> Only the legal entity which has executed a Participation Agreement and its Subsidiaries will be entitled to enjoy the rights and privileges of such OpenSSF Membership. </li>
+</br>
+    <li>If a OpenSSF Member is itself a foundation, association, consortium, open source project, membership organization, user group or other entity that has members or sponsors, then the rights and privileges granted to such OpenSSF Member will extend only to the employee-representatives of such OpenSSF Member, and not to its members or sponsors, unless otherwise approved by the Governing Board in a specific case.</li>
+</br>
+    <li>OpenSSF Membership is non-transferable, non-salable and non-assignable, except a OpenSSF Member may transfer its current OpenSSF Membership benefits and obligations to a successor of substantially all of its business or assets, whether by merger, sale or otherwise; provided that the transferee agrees to be bound by this Charter and the Bylaws and policies required by LF membership.</li></ol>
+
+9. **Good Standing**
+<ol type="a">
+  <li>The Linux Foundation's Good Standing Policy is available at <https://www.linuxfoundation.org/good-standing-policy> and will apply to Members of the OpenSSF.</li></ol>
+
+10. **Trademarks**
+<ol type="a">
+  <li>
+
+  Any trademarks relating to the OpenSSF or a Technical Initiative, including without limitation any mark relating to any Conformance Program, must be transferred to and held by the Linux Foundation or one of its affiliates and available for use pursuant to the trademark usage policy of the Linux Foundation (available at [https://www.linuxfoundation.org/trademark-usage](https://www.linuxfoundation.org/trademark-usage) or such affiliate.</li></ol>
+
+11. **Antitrust Guidelines**
+<ol type="a">
+  <li>
+  
+  All Members must abide by The Linux Foundation's Antitrust Policy available at [http://www.linuxfoundation.org/antitrust-policy](http://www.linuxfoundation.org/antitrust-policy). </li>
+    <li>All Members must encourage open participation from any  organization able to meet the membership requirements, regardless of competitive interests. Put another way, the Governing Board will not seek to exclude any member based on any criteria, requirements or reasons other than those that are reasonable and applied on a non-discriminatory basis to all members.</li></ol>
+
+12. **Budget**
+<ol type="a">
+  <li>If the OpenSSF decides to raise funds, the Governing Board will
+        approve an annual budget and never commit to spend in excess of funds raised. The budget and the purposes to which it is applied must be consistent with both (a) the non-profit and tax-exempt mission of the Linux Foundation and (b) the aggregate goals of the Technical Initiatives.</li>
+        </br>
+  <li>The Linux Foundation will provide the Governing Board with regular reports of spend levels against the budget. Under no circumstances will the Linux Foundation have any expectation or obligation to undertake an action on behalf of the OpenSSF or otherwise related to the OpenSSF that is not covered in full by funds raised by the OpenSSF.</li>
+        </br>
+  <li>In the event an unbudgeted or otherwise unfunded obligation arises related to the OpenSSF, the Linux Foundation will coordinate with the Governing Board to address gap funding requirements.</li></ol>
+
+13. **General & Administrative Expenses**
+<ol type="a">
+  <li>The Linux Foundation will have custody of and final authority over the usage of any fees, funds and other cash receipts.</li>
+        </br>
+  <li>A General & Administrative (G&A) fee will be applied by the Linux Foundation to funds raised to cover membership records, finance, accounting, and human resources operations. The G&A fee will be 9% of the OpenSSF's first \$1,000,000 of gross receipts each year and 6% of the OpenSSF's gross receipts each year over \$1,000,000. Individual Technical Initiative funding arrangements may be setup under alternative arrangements by approval of the Governing Board and the Linux Foundation.</li></ol>
+
+14. **General Rules and Operations. The OpenSSF activities must:**
+<ol type="a">
+  <li>engage in the work of the project in a professional manner consistent with maintaining a cohesive community, while also maintaining the goodwill and esteem of the Linux Foundation in the open source community;</li>
+        </br>
+  <li>respect the rights of all trademark owners, including any branding and usage guidelines;</li>
+        </br>
+  <li>engage or coordinate with the Linux Foundation on all outreach, website and marketing activities regarding the OpenSSF or on behalf of any Technical Initiative that invoke or associate the name of any Technical Initiative or the Linux Foundation; and</li>
+        </br>
+  <li>operate under such rules and procedures as may be approved by the Governing Board and confirmed by the Linux Foundation.</li></ol>
+
+15. **Amendments**
+<ol type="a">
+  <li> This Charter may be amended by a two-thirds vote of the entire  Governing Board, subject to approval by The Linux Foundation.</li></ol>
+
+<center><h5><a name="exc"></a>Exhibit C</h5></center>
+
+The membership levels and associated fees are listed below.
+
+| **Membership Class**         |  **Annual Membership Fees**  |
+|------------------------------|------------------------------|
+| OpenSSF Member^1^            |  \$0                         |
+| Associate Member (pre-approved non-profits, open source projects, and government entities)   |  \$0                    |
+
+
+**Linux Foundation Membership Information.** Your organization will need to be a current member of the LF. If your organization is already a member of the LF, there is no need to do anything. If you are not a member of the LF, there are three tiers of LF membership available. The fees associated with each level of LF membership are included below for non-members to easily reference. Please visit the Corporate Membership page at the LF web site for full details:
+
+-   LF Platinum: \$500,000
+
+-   LF Gold: \$100,000
+
+-   LF Silver: Under 100 employees: \$5,000; 100-499 employees:
+    \$10,000; 500-4,999 employees: \$15,000; 5,000 or more employees:
+    \$20,000.
+
+-   LF Associate membership is available for non-profit, open source,
+    and government entities at no cost.


### PR DESCRIPTION
converted word doc to markdown for further maintenance. admittedly, this is as much html as markdown, but the nested ordered lists necessitated this approach.

Signed-off-by: Chris Ferris <chrisfer@us.ibm.com>