### PR TITLE
Add link to Slack

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,4 +21,4 @@ Open source software has become pervasive in data centers, consumer devices, and
 * [Open SSF Community Calendar](https://calendar.google.com/calendar/r?cid=czYzdm9lZmhwNWk5cGZsdGI1cTY3bmdwZXNAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ)
 * [Open SSF Mailing Lists](https://lists.openssf.org/g/main)
 * [Open SSF web site](https://openssf.org/)
-* [Open SSF Slack](https://slack.openssl.org/)
+* [Open SSF Slack](https://slack.openssf.org/)

--- a/README.md
+++ b/README.md
@@ -21,3 +21,4 @@ Open source software has become pervasive in data centers, consumer devices, and
 * [Open SSF Community Calendar](https://calendar.google.com/calendar/r?cid=czYzdm9lZmhwNWk5cGZsdGI1cTY3bmdwZXNAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ)
 * [Open SSF Mailing Lists](https://lists.openssf.org/g/main)
 * [Open SSF web site](https://openssf.org/)
+* [Open SSF Slack](https://slack.openssl.org/)


### PR DESCRIPTION
Hi,

Slack link was missing and broken.
This PR adds the correct link in the readme.

Closes #15