### PR TITLE
Add CHARTER.md

### DIFF
--- a/CHARTER.md
+++ b/CHARTER.md
@@ -1,0 +1,421 @@
+# The Open Source Security Foundation Charter
+    As Amended 6 January 2022
+
+1. Mission and Scope of the Open Source Security Foundation.
+
+   a) The purpose of the Open Source Security Foundation (the “OpenSSF”) is to
+inspire and enable the community to secure the open source software we all
+depend on, including development, testing, fundraising, infrastructure, and
+support initiatives driven by Working Groups (non- software focused) and
+Projects (software focused), each a “Technical Initiative”. The governance of
+each Technical Initiative will be as set forth in the applicable charter for
+each Technical Initiative. Participation in Technical Initiatives will be open
+to anyone, regardless of membership.
+
+   b) The OpenSSF raises funds to support the Technical Initiatives. The OpenSSF
+operates under the guidance of the Governing Board of the OpenSSF (the
+“Governing Board”) and The Linux Foundation (the “LF”) as may be consistent with
+The Linux Foundation’s tax-exempt status.
+
+   c) The Governing Board manages the OpenSSF. The OpenSSF will also have
+Committees that may be established by the Governing Board. Committees report to
+the Governing Board. Working Groups and Projects may be established under the
+Technical Advisory Council (the “TAC”).
+
+2. Membership.
+
+   a) The OpenSSF will be composed of Premier, General and Associate Members
+(each, a “Member” and, collectively, the “Members”, or, alternatively, “OpenSSF
+Member” and “OpenSSF Members”, respectively) in Good Standing. All OpenSSF
+Members must be current corporate members of the LF (at any level) to
+participate in the OpenSSF as a OpenSSF Member. All participants in the OpenSSF
+enjoy the privileges and undertake the obligations described in this Charter, as
+from time to time amended by the Governing Board with the approval of the LF.
+During the term of their membership, all OpenSSF Members will comply with all
+such policies as the LF Board of Directors and/or the OpenSSF may adopt with
+notice to members.
+
+   b) Premier Members will be entitled to appoint a representative to the
+Governing Board and any Committee.
+
+   c) General Members, acting as a class, will be entitled to annually elect one
+representative to the Governing Board for every ten General Members, up to a
+maximum of three representatives, provided that there will always be at least
+one General Member representative, even if there are less than ten General
+Members. The Governing Board determines the election process.
+
+   d) The Associate Member category of OpenSSF Membership is limited to
+Associate Members of The Linux Foundation. The Governing Board may establish
+additional criteria for joining the OpenSSF as an Associate Member. If the
+Associate Member is a membership organization, Associate Membership in the
+OpenSSF does not confer any benefits or rights to the members of the Associate
+Member.
+
+   e) OpenSSF Members will be entitled to:
+
+     1) participate in OpenSSF general meetings, initiatives, events and any
+        other activities; and
+
+     1) identify themselves as members of the OpenSSF and have their logo or
+name displayed on materials denoting the OpenSSF Members.
+
+3) Governing Board
+
+   a) The Governing Board voting membership will consist of:
+
+     1) one representative appointed by each Premier Member;
+
+     1) the elected General Member representative or representatives;
+
+     1) one TAC Representative (as defined herein);
+
+     1) one Associate Member Representative appointed by the OpenSSF Governing
+Board; and
+
+     1) one Security Community Individual Representative elected by
+contributors to Technical Initiatives.
+
+    b) Each Premier Member shall have the right to designate a single observer
+to attend telephonic meetings of the Governing Board on a standing basis that
+shall not exceed designating more than two different individuals as an observer
+within a twelve-month period. If the TAC Representative is unable to be present
+at a meeting, the TAC Representative may appoint an observer from the TAC
+membership to attend and participate in a meeting, provided that the TAC
+Representative provides prior notice to the General Manager. Observers may have
+the right to participate in any sessions, attend meetings in person, but shall
+not put forth or vote on any motion.
+
+    c) If the election of any of the TAC Representative, Associate Member
+Representative, or Security Community Individual Representative would result in
+a group of Related Companies having three votes, the respective role will be
+non-voting.
+
+    d) The Associate Member Representative will serve a renewable one-year term
+coinciding with the regular annual OpenSSF General Member elections.
+
+    e) The Security Community Individual Representative will be elected by the
+contributors to technical projects during the regular annual TAC election. The
+TAC Representative shall be the chairperson of the TAC, elected by the TAC
+shortly after the regular annual TAC election.
+
+    f) The representatives appointed by Premier Members, elected by General
+Members, and the Associate Member Representative each represent their respective
+Member organizations and may be replaced by their Member organization.
+
+    g) If more than two representatives on the Governing Board are employed by
+the same Member or by a group of Related Companies (as defined in Section 8),
+those members will have their number of votes limited to two votes across all
+Related Companies.
+
+    h) Conduct of Meetings
+
+      1) Governing Board meetings will be limited to the Governing Board
+representatives, designated observers, Committee chairpersons, invited guests
+and LF staff.
+
+      2) Governing Board meetings follow the requirements for quorum and voting
+outlined in this Charter.
+
+      3) The Governing Board meetings will be private unless decided otherwise
+by the Governing Board. The Governing Board may invite guests (e.g. committee
+chairpersons) to participate in consideration of specific Governing Board topics
+(but such guests may not participate in any vote on any matter before the
+Governing Board). The Governing Board may choose to hold open, community
+meetings at its discretion.
+
+    i) Officers
+
+      1) The officers (“Officers”) of the OpenSSF Governing Board will be a
+Chairperson (“Chair”). Additional Officer positions may be created by the
+Governing Board.
+
+      2) Officers will assist any OpenSSF staff with execution objectives and
+priorities that will further the OpenSSF mission.
+
+      3) The Chair will preside over meetings of the Governing Board, and will
+submit minutes for Governing Board approval.
+
+      4) The chair of the budget committee will assist LF staff in the
+preparation of budgets for Governing Board approval, monitor expenses against
+the budget and authorize expenditures approved in the budget.
+
+      5) Officers will serve for a period of one year until their successors are
+         elected and qualified.
+
+    j) The Governing Board will be responsible for overall management of the
+OpenSSF, including:
+
+      1) approve procedures for the nomination and election of any
+representative to the Governing Board and any Officer or other positions created
+by the Governing Board;
+
+      1) Establish any criteria for organizations to become Associate Members of
+the OpenSSF;
+
+      1) oversee all OpenSSF business and community outreach matters and work
+with the LF on any legal matters that arise;
+
+      1) adopt and maintain policies or rules and procedures for the OpenSSF
+(subject to LF approval);
+
+      1) nominate and elect Officers of the OpenSSF Governing Board;
+
+      1) establish advisory bodies, committees, programs or councils to support
+the mission of the OpenSSF and/or its Technical Initiatives, including in
+support of end-users and ambassadors for the project;
+
+      1) approve a budget directing the use of funds raised by the OpenSSF from
+all sources of revenue for the OpenSSF;
+
+      1) approve directed fundraising proposals for specific Working Groups or
+Projects that will raise and spend funds within the Working Group or Project;
+
+      1) establish any conformance programs and solicit input (including testing
+tools) from the applicable governance body of any Technical Initiative for
+defining and administering any programs related to conformance with any
+Technical Initiative (each, a “Conformance Program”);
+
+      1) publish use cases, user stories, websites and priorities to help inform
+the ecosystem and technical community;
+
+      1) facilitate crowdfunding opportunities in support of OpenSSF Technical
+Initiatives; and
+
+      1) vote on all decisions or matters coming before the Governing Board.
+
+4) Committees
+
+   a) Any Committee may include one appointed voting representative from each
+Governing Board Representative.
+
+   b) The Governing Board will define the purpose, composition, and scope of
+each Committee. Committees are expected to coordinate closely with the Governing
+Board and relevant technical communities to maximize consensus building
+throughout the OpenSSF.
+
+   c) The Governing Board may appoint a chairperson of any Committee or delegate
+responsibility for selecting a chairperson to a Committee. Each Committee
+chairperson will be responsible for reporting progress back to the Governing
+Board. A Committee chairperson may attend meetings of the Governing Board, but,
+unless the Committee chairperson is a member of the Governing Board, the
+Committee chairperson will not attend as a voting member of the Governing Board.
+
+5) Intellectual Property Policy
+
+   a) Unless otherwise approved by the Governing Board, each Technical
+Initiative supported by OpenSSF may accept contributions and release
+deliverables licensed according to the following:
+
+     1) Software source code
+
+        (1) Apache License, Version 2.0, available at
+https://www.apache.org/licenses/LICENSE- 2.0; or
+
+        (2) MIT License available at https://opensource.org/licenses/MIT;
+     1) Data
+
+        (1) Any of the Community Data License Agreements, available at
+        https://www.cdla.io;
+     1) Specifications
+
+        (1) Community Specification License, Version 1.0, available at
+https://github.com/CommunitySpecification/1.0
+
+     1) All other Documentation
+
+        (1) Creative Commons Attribution 4.0 International License, available at
+https://creative commons.org/licenses/by/4.0/.
+
+   b) Technical Initiatives will require that all new inbound source code
+contributions must also be accompanied by a Developer Certificate of Origin
+(https://developercertificate.org) sign-off in the source code system that is
+submitted through a TAC-approved contribution process which will bind the
+authorized contributor and, if not self-employed, their employer to the
+applicable license;
+
+   c) A Technical Initiative may seek to integrate and contribute back to other
+open source projects ("Upstream Projects"). In such cases, the Technical
+Initiative will conform to all license requirements of the Upstream Projects,
+including dependencies, leveraged by the Technical Initiative. Upstream Project
+code contributions not stored within the Technical Initiative's main code
+repository will comply with the contribution process and license terms for the
+applicable Upstream Project.
+
+6) Technical Advisory Council
+
+   a) The TAC will be composed of four representatives elected -annually by all
+active contributors to technical projects (as defined by the TAC) and three
+representatives appointed by the Governing Board.
+
+   b) OpenSSF Members that are part of a group of Related Companies (as defined
+in Section 8) may have no more than two voting representatives on the TAC.
+
+   c) The role of the TAC is to structure and facilitate collaboration among the
+Technical Initiatives. The TAC will be responsible for:
+
+    1) developing an overall technical vision for the community;
+
+    1) establishing, structuring, organizing, and archiving Technical
+Initiatives, including the approval of the Technical Initiative charter;
+
+    1) creating, maintaining and amending project lifecycle states, review
+procedures and processes;
+
+    1) working with the Technical Initiatives to identify any resource or
+funding requirements and prioritizing recommendations to the Governing Board;
+
+    1) facilitating crowdfunding opportunities in support of OpenSSF Technical
+Initiatives;
+
+    1) annually electing a chairperson to preside over meetings, set the agenda
+for meetings, ensure meeting minutes are taken, and who will also serve on the
+Governing Board as the TAC’s representative (the “TAC Representative”); and
+
+    1) coordinating such other technical community matters related to the
+success of Technical Initiatives and the mission of the OpenSSF.
+
+   d) TAC, Working Group and Project meetings shall be open, public meetings.
+For special circumstances, the TAC may hold meetings limited to the TAC voting
+representatives, invited guests, and LF staff.
+
+7) Voting
+
+   a) Quorum for Governing Board, Committee, and TAC meetings will require at least
+fifty percent of the voting representatives in good standing. If advance notice
+of the meeting has been given per normal means and timing, with at least 7 days
+notice for meetings to make ordinary decisions, the meeting may continue to meet
+even if quorum is not met, but will be prevented from voting on any decisions at
+the meeting.
+
+     1) A voting representative must have attended two of the preceding three
+meetings to be counted as in good standing for the purposes of Quorum. Voting
+rights will be reinstated at the meeting after the voting representative has
+attended two of the prior three meetings.
+
+   b) Ideally decisions will be made based on consensus. If, however, any decision
+requires a vote to move forward, the voting representatives will vote on a one
+vote per voting representative basis.
+
+   c) Except as provided in Section 15.a. or elsewhere in this Charter, decisions
+by vote at a meeting will require a simple majority vote, provided quorum is
+met. Except as provided in Section 15.a. or elsewhere in this Charter, decisions
+by electronic vote without a meeting will require a majority of all voting
+representatives.
+
+   d) In the event of a tied vote with respect to an action that cannot be resolved
+by the TAC, the TAC Representative may refer the matter to the Governing Board.
+In the event of a tied vote with respect to an action that cannot be resolved by
+the Governing Board, the chairperson may refer the matter to the LF for
+assistance in facilitating a decision.
+
+8) Subsidiaries and Related Companies
+
+   a) Definitions:
+
+    1) “Subsidiaries” means any entity in which a Member owns, directly or
+indirectly, more than fifty percent of the voting securities or voting
+membership interests of the entity in question;
+
+    1) “Related Company” means any entity which controls or is controlled by a
+Member or which, together with a Member, is under the common control of a third
+party, in each case where such control results from ownership, either directly
+or indirectly, of more than fifty percent of the voting securities or voting
+membership interests of the entity in question; and
+
+    1) “Related Companies” are entities that are each a Related Company of a
+Member.
+
+   b) Only the legal entity which has executed a Participation Agreement and its
+Subsidiaries will be entitled to enjoy the rights and privileges of such OpenSSF
+Membership.
+
+   c) If a OpenSSF Member is itself a foundation, association, consortium, open
+source project, membership organization, user group or other entity that has
+members or sponsors, then the rights and privileges granted to such OpenSSF
+Member will extend only to the employee- representatives of such OpenSSF Member,
+and not to its members or sponsors, unless otherwise approved by the Governing
+Board in a specific case.
+
+   d) OpenSSF Membership is non-transferable, non-salable and non-assignable,
+except an OpenSSF Member may transfer its current OpenSSF Membership benefits
+and obligations to a successor of substantially all of its business or assets,
+whether by merger, sale or otherwise; provided that the transferee agrees to be
+bound by this Charter and the Bylaws and policies required by LF membership.
+
+9) Good Standing
+
+   a) The Linux Foundation’s Good Standing Policy is available at
+https://www.linuxfoundation.org/good-standing-policy and will apply to Members
+of the OpenSSF.
+
+10) Trademarks
+
+    a) Any trademarks relating to the OpenSSF or a Technical Initiative, including
+without limitation any mark relating to any Conformance Program, must be
+transferred to and held by the Linux Foundation or one of its affiliates and
+available for use pursuant to the trademark usage policy of the Linux Foundation
+(available at https://www.linuxfoundation.org/trademark-usage) or such
+affiliate.
+
+11) Antitrust Guidelines
+
+    a) All Members must abide by The Linux Foundation’s Antitrust Policy available
+at http://www.linuxfoundation.org/antitrust-policy.
+
+    b) All Members must encourage open participation from any organization able to
+meet the membership requirements, regardless of competitive interests. Put
+another way, the Governing Board will not seek to exclude any member based on
+any criteria, requirements or reasons other than those that are reasonable and
+applied on a non-discriminatory basis to all members.
+
+12) Budget
+
+    a) The Governing Board will approve an annual budget and never commit to spend
+in excess of funds raised. The budget and the purposes to which it is applied
+must be consistent with both (a) the non-profit and tax-exempt mission of the
+Linux Foundation and (b) the aggregate goals of the Technical Initiatives.
+
+    b) The Linux Foundation will provide the Governing Board with regular reports of
+spend levels against the budget. Under no circumstances will the Linux
+Foundation have any expectation or obligation to undertake an action on behalf
+of the OpenSSF or otherwise related to the OpenSSF that is not covered in full
+by funds raised by the OpenSSF.
+
+    c) In the event an unbudgeted or otherwise unfunded obligation arises related to
+the OpenSSF, the Linux Foundation will coordinate with the Governing Board to
+address gap funding requirements.
+
+13) General & Administrative Expenses
+
+    a) The Linux Foundation will have custody of and final authority over the usage
+of any fees, funds and other cash receipts.
+
+    b) A General & Administrative (G&A) fee will be applied by the Linux Foundation
+to funds raised to cover membership records, finance, accounting, and human
+resources operations. The G&A fee will be 9% of the OpenSSF’s first $1,000,000
+of gross receipts each year and 6% of the OpenSSF’s gross receipts each year
+over $1,000,000. Individual Technical Initiative funding arrangements may be
+setup under alternative arrangements by approval of the Governing Board and the
+Linux Foundation.
+
+14) General Rules and Operations. The OpenSSF activities must:
+
+    a) engage in the work of the project in a professional manner consistent with
+maintaining a cohesive community, while also maintaining the goodwill and esteem
+of the Linux Foundation in the open source community;
+
+    b) respect the rights of all trademark owners, including any branding and usage
+guidelines;
+
+    c) engage or coordinate with the Linux Foundation on all outreach, website and
+marketing activities regarding the OpenSSF or on behalf of any Technical
+Initiative that invoke or associate the name of any Technical Initiative or the
+Linux Foundation; and
+
+    d) operate under such rules and procedures as may be approved by the Governing
+Board and confirmed by the Linux Foundation.
+
+15) Amendments
+
+    a) This Charter may be amended by a two-thirds vote of the entire Governing
+Board, subject to approval by The Linux Foundation.


### PR DESCRIPTION
This imports the charter text from the January draft copy
which the TAC has been using.

I have formatted so that the paragraph headings and identifiers
match the original.

Signed-off-by: Aeva Black <806320+AevaOnline@users.noreply.github.com>