### PR TITLE
Create OpenSSF Policies and Procedures.md

### DIFF
--- a/OpenSSF Policies and Procedures.md
+++ b/OpenSSF Policies and Procedures.md
@@ -1,0 +1,159 @@
+# OpenSSF Policies & Procedures
+
+## Preamble
+The Policies and Procedures (P&P) document how decisions are made, committees form
+and behave, and how all the other day-to-day work needs to happen. Documenting all the
+P&P in one place provides the following benefits:
+- Slow moving charter is separate from faster evolving P&P.
+- P&P can more easily evolve to the complexity of the growing organizational
+architecture of participation.
+- All committees get the benefit of evolving participative organizational knowledge.
+- The P&P are consistently documented.
+- It’s clear in a large organization that ALL committees are created by a board
+resolution that sets scope, initial membership, and any delegated authority, and then
+behave the same way.
+
+**These P&P are not intended to be templates for committees and other subgroups to
+use and edit. They are the P&P that apply to all. Differences from the P&P between
+committees (or TAC WGs for example) should be noted in the formation decisions of
+their parent organization.**
+
+# Governing Board 
+
+## Committees
+The Governing Board creates committees to carry out operational work. A committee can either be a standing committee that exists at all times (although it may only meet as
+needed), or an ad hoc committee that is created to accomplish a specific task (e.g., create a
+report) and possibly for a fixed period of time.
+
+## Committee Creation/Dissolution
+1. The GB creates committees by a resolution and sets their type (standing or ad hoc),
+scope, and mission or expected outcomes in a resolution. As well, the GB can
+delegate authority in the specific charter to the committee for decisions/work that
+does not require GB approval.
+2. Ad Hoc committees cease to exist once their task is complete and delivered to the
+GB or time limit has expired. The GB can extend the life of Ad Hoc by resolution.
+3. The GB can dissolve a committee by resolution.
+4. Committees inherit rules for quorum and voting from the GB.
+5. Committees are expected to report regular status to the GB.
+
+## Committee Membership
+1. The GB calls for initial member volunteers as they form the committee. Every
+Premier Member is entitled to appoint one representative as a voting committee
+member. Only premier members can be voting members.
+2. The list of voting committee members is recorded and maintained by LF staff for
+roll-call at the beginning of meetings to establish quorum, and for voting purposes
+(whether in meetings or by electronic means). To maintain voting privileges,
+committee members must attend 2 of the last 3 meetings.
+3. Newly joined (to OpenSSF premier membership) representatives may be added to a
+committee voting membership if they have attended the previous two meetings and
+have sufficient committee function context.
+4. The voting membership is representative of the premier member company, not the
+individual. A voting member of a committee can send a delegate to act as their voting
+representative to a meeting. The delegate needs to identify themselves (who they are
+and who they are attending on behalf of) during the roll call at the beginning of the
+meeting. Scheduling conflicts may happen but that shouldn’t mean automatic loss of
+votes, delegate assignment conveys the interest of the member despite conflicts.
+5. Member representatives can be replaced by their appointing Premier Member by
+notifying LF staff of the change in personnel.
+6. A Premier Member (or their representative) can resign their committee position by
+notifying Linux Foundation staff.
+7. If a voting committee member is deemed to be dormant and unreachable, then the
+rest of the voting committee members can vote to remove the member. Dormant is
+defined as having missed 5 consecutive meetings without sending a delegate.
+8. The GB can appoint non-member specialists to a committee in special cases. Such
+special cases should be recorded in the formation GB resolution. These specialists
+will act as subject matter experts, but may not have voting rights except as defined in
+the charter (currently limited to premier members).
+9. General members can send representatives to committees to participate, but they
+are non-voting members of the committee.
+10. Premier members can have more than one representative of the company attend
+committee meetings, but only one will be a voting member.
+
+## Committee Officers
+1. The committee elects a chairperson.The committee can elect co-chairs or vice-chairs
+as they see fit. These roles are collectively known as the committee officers.
+2. Officers must be voting members of the committee.
+3. Elected positions serve for a year or until their successors are elected. A committee
+member serving in a position can be re-elected in subsequent years.
+4. LF staff run the election (gathering candidate nominations, running the ballot,
+announcing and recording the outcome) in a reasonable manner.
+5. The election calendar should be in the Fall, coordinating with LF staff to manage the
+workload of running elections.
+6. The chairperson is responsible for calling the meeting, setting and publishing the
+agenda before the meeting, and running the meeting.
+7. The chairperson is responsible for providing regular status updates to the GB. If the
+chairperson is invited to attend other committee meetings or the GB, they do so as a
+guest without voting privileges.
+
+## Meetings
+1. The Committee determines the frequency of meetings to get their work done. For
+example, a Code-of-Conduct Committee might only meet (in camera) if there are
+code-of-conduct reports to discuss, while a Marketing Committee might meet every
+other week.
+2. A closed meeting includes only voting members of the committee. For transparency,
+most meetings should be open unless there is a compelling reason to have a closed
+meeting. An example of why a committee may choose a closed meeting is if a
+confidential situation arises (e.g., a Code of Conduct report).
+3. Committee meeting attendees will be recorded as well as any decisions,
+recommendations, and reports out of the committee to the GB.
+4. All committee artifacts (e.g., minutes, reports, etc.) will be recorded by LF staff and
+available to any GB member, unless explicitly kept private due to the sensitive nature
+of the work (e.g., artifacts pertaining to a code of conduct discussion).
+5. While minutes covering attendance and decisions should be recorded, minutes of a
+Committee need not be approved by the Committee.
+
+## Committee Work
+1. A committee organizes their work as they see fit. For example, a committee can
+create required subcommittees to organize their work or engage specific
+communities (e.g., the DevRel Subcommittee under the Marketing Committee) or
+work towards specific tasks (e.g., prepare a conference report).
+
+## Additional Committee Voting Policies
+1. Quorum is at least 1⁄2 of all voting Members (when voting either synchronous in a
+meeting or asynchronous by email).
+2. A vote passes if it passes by a majority of eligible voters (more than 50%)
+participating in the vote. Voting may be done asynchronously (by email), but in that
+case the voting period must be no less than 2 full US non-Federal-holiday business
+days or it must be approved by 50% of all eligible voters in the committee.
+
+## General Member Representatives
+1. The Governing Board determines the election process for General Member
+Representatives to the GB.
+2. The GB:
+  a. Requests LF staff to run a formal call for candidates within the candidate pool
+of General Members with a reasonable 1-2 week period for candidates to
+identify themselves.
+  b. Following the collection of candidates, LF staff run a Condorcet vote amongst
+the General Members, and announce the winner to the General Members and
+GB.
+4. General Member Representatives serve for a year or until their successors are
+elected
+5. A General Member Representative can stand as a candidate for election in
+subsequent years.
+6. The election calendar should be in the Fall, coordinating with LF staff to manage the
+workload of running elections.
+7. If a General Member representative to the GB resigns their position, and there are
+still at least N months left in their term, the member with the next most votes can
+finish out the term. If that subsequent member on the list cannot serve for any
+reason, the member getting the next most votes is selected, and so on. If no member
+from the original election is able to finish the term, then General members should
+hold a new election.
+
+## Amending the Policies & Procedures
+The OpenSSF Policies & Procedures may be amended by a two thirds vote (excluding
+abstensions) of Governing Board members in good standing per section 7.a.i.
+- Store in the GC github, and document pain points and suggested improvements in
+pull requests and issues
+- Review semi-annually, or as a priority ad hoc issue arises
+- If updates are raised, plan to make quarterly releases of updates that are raised in
+line with quarterly board meetings. As the GB P&P process is newly adopted, there
+will most likely be a flurry of activity to address, and the review / release process will
+go into more of a maintenance review cadence.
+- As ongoing work is requested, GC chair should coordinate with the GM (who will
+recommend the appropriate staff to participate), TAC Chair, Committee chairs, plus
+other interested board members and relevant SMEs. Work should be prioritized,
+accomplished asynchronously from the GC meetings, with updates on work progress
+in the GC meetings. An ongoing list of clarifications to use as a starting point: Intro to
+OpenSSF Charter, Policies, and Procedures - Google Docs.
+- GC will make recommendation vote to update P&P language, with lazy consensus by
+the GB


### PR DESCRIPTION
Add the OpenSSF Policies and Procedures document to the foundation GH repo for a more accessbile and public location. This document was approved by the governing board in December 2023. Please note that I have left off the Background section of the document - if needed, I can add a blurb at the bottom and link to the full document.